### PR TITLE
Don't camel-case css vars in element styles

### DIFF
--- a/src/hx/utils.cljs
+++ b/src/hx/utils.cljs
@@ -66,8 +66,10 @@
   (if (or (keyword? s)
           (string? s)
           (symbol? s))
-    (let [[first-word & words] (str/split (name s) #"-")]
+    (let [as-string (name s)
+          [first-word & words] (str/split as-string #"-")]
       (if (or (empty? words)
+              (str/starts-with? as-string "--")
               (= "aria" first-word)
               (= "data" first-word))
         s

--- a/test/hx/react_test.cljs
+++ b/test/hx/react_test.cljs
@@ -105,6 +105,9 @@
   (t/is (node= (html "<div style=\"color: red;\">hi</div>")
                (root (render (hx/f [:div {:style {:color "red"}} "hi"])))))
 
+  (t/is (node= (html "<div style=\"--some-var:foo;\">hi</div>")
+               (root (render (hx/f [:div {:style {:--some-var "foo"}} "hi"])))))
+
   (t/is (node= (html "<div style=\"color: red; background: green;\">hi</div>")
                (root (render (hx/f [:div {:style {:color "red"
                                                   :background "green"}} "hi"])))))


### PR DESCRIPTION
React supports setting css vars in inline styles for some time now (since before 16) but hx converting styles to camelCase was breaking things. This is a quick fix with an accompanying test.